### PR TITLE
To BE TESTED CAREFULLY - add TTL option for Pushover

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ All switches can be used in scenes and automation.
                   "text": "This is a test",
                   "sound": "pushover",
                   "device" : "iphone",
-                  "priority": 0
+                  "priority": 0,
+                  "ttl": 600
               },
               {
                   "type": "pushover",
@@ -98,6 +99,7 @@ All switches can be used in scenes and automation.
     * text *(required)*: Body of the message.
     * sound *(facultative)*: Name of the sound that will notify the user. If no valid value is provided, the default `pushover` sound will be used. For no sound, use `silent`. The [Pushover API](https://pushover.net/api#sounds) contains the list of all available sounds.
     * device *(facultative)*: The device name to send the message to. If not specified, the message will be send to all your devices. You can send to multiple devices by using a coma.
+    * ttl *(facultative)*: Time To Live = a number of seconds that the message will live, before being deleted automatically. This will be ignored, if priority is `2`. Leave blank or remove key from config or set to `0` for infinite TTL.
     * priority *(required)*: Priority of the message. Accepted values are `-2`, `-1`, `0`, `1` or `2`. You may refer to the [Pushover API](https://pushover.net/api#priority) for more details. Critical messages (`2`), are sent with the following parameters :
         * Retry : 60 seconds
         * Expires: 3600 seconds

--- a/config.schema.json
+++ b/config.schema.json
@@ -201,6 +201,13 @@
                 }
               ]
             },
+            "ttl": {
+              "title": "TTL",
+              "type": "integer",
+              "minimum": 1,
+              "description": "Time To Live: message is deleted on the device/phone x seconds after reception.<br />(1 to 65535 or empty for infinite TTL)",
+              "required": false
+            },
             "sound": {
               "title": "Sound",
               "type": "string",
@@ -505,6 +512,11 @@
             {
               "key": "messages[].sound",
               "flex-basis": "50%",
+              "condition": "messages[arrayIndex].type==pushover"
+            },
+            {
+              "key": "messages[].ttl",
+              "flex-basis": "100%",
               "condition": "messages[arrayIndex].type==pushover"
             },
             {

--- a/config.schema.json
+++ b/config.schema.json
@@ -204,8 +204,8 @@
             "ttl": {
               "title": "TTL",
               "type": "integer",
-              "minimum": 1,
-              "description": "Time To Live: message is deleted on the device/phone x seconds after reception.<br />(1 to 65535 or empty for infinite TTL)",
+              "minimum": 0,
+              "description": "Time To Live: message is deleted on the device/phone x seconds after reception.<br />(0 or empty for infinite TTL)",
               "required": false
             },
             "sound": {

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ class HomebridgeMessenger {
                   this.messages[x].text,
                   this.messages[x].priority,
                   this.messages[x].device,
+                  this.messages[x].ttl,
                   this.messages[x].sound,
                   this.messages[x].url,
                   this.messages[x].urltitle)

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -7,12 +7,13 @@ const MESSAGE_EXPIRE = 3600;
 const HTML = 1;
 
 module.exports = class PushOverMessenger {
-    constructor(pushoverUser, pushoverToken, messageTitle, messageText, messagePriority, messageDevice ,messageSound, url, urlTitle) {
+    constructor(pushoverUser, pushoverToken, messageTitle, messageText, messagePriority, messageDevice, messageTTL, messageSound, url, urlTitle) {
         this.pushover_user = pushoverUser
         this.pushover_token = pushoverToken
         this.message_title = messageTitle
         this.message_text = messageText
         this.message_priority = messagePriority
+        this.message_ttl = messageTTL
         this.message_device = messageDevice
         this.message_sound = messageSound
         this.message_url = url
@@ -32,6 +33,9 @@ module.exports = class PushOverMessenger {
 
         if (![-2, -1, 0 , 1, 2].includes(this.message_priority))
             throw new Error(this.message_title + " : Invalid priority value " + this.message_priority);
+
+        if (this.message_ttl < 0 || this.message_ttl > 65535)
+            throw new Error(this.message_title + " : TTL must between 0 an 65535 (seconds)");
 
         if (this.message_device)
             this.message_device = this.message_device.replace(/\s/g,'')
@@ -59,6 +63,7 @@ module.exports = class PushOverMessenger {
             title: this.message_title,
             device : this.message_device,
             priority: this.message_priority,
+            ttl: this.message_ttl,
             sound : this.message_sound,
             url : this.message_url,
             url_title : this.message_urltitle,

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -34,8 +34,11 @@ module.exports = class PushOverMessenger {
         if (![-2, -1, 0 , 1, 2].includes(this.message_priority))
             throw new Error(this.message_title + " : Invalid priority value " + this.message_priority);
 
-        if (this.message_ttl < 1 || this.message_ttl > 65535)
-            throw new Error(this.message_title + " : TTL must between 1 and 65535 (seconds)");
+        if (this.message_ttl == 0)
+            this.message_ttl = null;
+
+        if (this.message_ttl != null && this.message_ttl < 1)
+            throw new Error(this.message_title + " : TTL must not be less than 1 (sec). Set '0' or leave it empty for unlimited TTL");
 
         if (this.message_device)
             this.message_device = this.message_device.replace(/\s/g,'')

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -34,8 +34,8 @@ module.exports = class PushOverMessenger {
         if (![-2, -1, 0 , 1, 2].includes(this.message_priority))
             throw new Error(this.message_title + " : Invalid priority value " + this.message_priority);
 
-        if (this.message_ttl < 0 || this.message_ttl > 65535)
-            throw new Error(this.message_title + " : TTL must between 0 an 65535 (seconds)");
+        if (this.message_ttl < 1 || this.message_ttl > 65535)
+            throw new Error(this.message_title + " : TTL must between 1 and 65535 (seconds)");
 
         if (this.message_device)
             this.message_device = this.message_device.replace(/\s/g,'')


### PR DESCRIPTION
I am NOT A CODER or DEVELOPER! PLEASE TEST this CAREFULLY.

@svobs [I have done this patch against](https://github.com/potrudeau/homebridge-messenger/pull/44) @potrudeau's repo. But it seems that he is not active with this plugin any more. And now I see, that your fork is found in homebridge's plugin section too.

My patch did not show any conflicts with your repo, so I decided to try to PR this here. I have not tested this against your fork, so please test it carefully.

It is adding the TTL feature (Time To Live) for Pushover, where we can set the time in seconds, when the message will automatically be deleted on the receiving platform. Example: HomeKit is sending me a Pushover, when my doorbell rings. And now there is no need any longer to delete every message on every platform (phone, tablet, browser, girlfriend's phone...) by hand every no and then. TTL=300 and its gone after 5 minutes.